### PR TITLE
fix: pull tags before pushing them

### DIFF
--- a/packages/lerna-semantic-release-io/io/git.js
+++ b/packages/lerna-semantic-release-io/io/git.js
@@ -26,6 +26,9 @@ module.exports = {
   push: function push () {
     return execAsTask('git push origin');
   },
+  pullTags: function pullTags () {
+    return execAsTask('git pull --tags');
+  },
   pushTags: function pushTags () {
     return execAsTask('git push origin --tags');
   },

--- a/packages/lerna-semantic-release-io/mocks/io/git.js
+++ b/packages/lerna-semantic-release-io/mocks/io/git.js
@@ -69,6 +69,7 @@ module.exports = {
     done(null, module.exports._state.head)
   },
   push: makeMockTask(sandbox),
+  pullTags: makeMockTask(sandbox),
   pushTags: makeMockTask(sandbox),
   add: makeMockTask(sandbox)
 };

--- a/packages/lerna-semantic-release-perform/index.js
+++ b/packages/lerna-semantic-release-perform/index.js
@@ -11,6 +11,12 @@ function pushTags (done) {
   });
 }
 
+function pullTags (done) {
+  this.io.git.pullTags()(function(err) {
+    done(err);
+  });
+}
+
 function pushCommits (done) {
   this.io.git.push()(function(err) {
     done(err);
@@ -113,6 +119,7 @@ function writeReleasedPackagesFile (releasedPackages, done) {
 module.exports = function perform (config) {
   async.waterfall(bindTasks([
     pushCommits,
+    pullTags,
     pushTags,
     getUpdatedPackages,
     publishUpdatedPackages,


### PR DESCRIPTION
When running locally, it is possible that tags have changed on the remote, therefore we should call `git pull --tags` before pushing the new ones.

@jpnelson unfortunately the tests seem to fail for some reason with

```
Error: ENOENT, no such file or directory '.released-packages'
```

do you have an idea how the change could have affected this?
