### PR TITLE
fix: pass flags before remote

### DIFF
--- a/packages/lerna-semantic-release-io/io/git.js
+++ b/packages/lerna-semantic-release-io/io/git.js
@@ -24,7 +24,7 @@ module.exports = {
   },
   head: gitHead,
   pull: function pull () {
-    return execAsTask('git pull origin --no-edit');
+    return execAsTask('git pull --ff-only --no-edit origin');
   },
   push: function push () {
     return execAsTask('git push origin');


### PR DESCRIPTION
old git versions can't deal with the cmd options at the end

affects: lerna-semantic-release-io
