### PR TITLE
chore: do not use npmrc file to allow local install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
-username=atlassian-aui
-email=aui-team@atlassian.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
 node_js:
   - "5"
 before_script:
-  - npm config set registry //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+  - npm config set registry https://registry.npmjs.org/:_authToken=${NPM_TOKEN}
   - npm prune
   - git config --global user.email "jonelson+lerna-sr-travis-ci@atlassian.com"
   - git config --global user.name "Joshua Nelson"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ notifications:
 node_js:
   - "5"
 before_script:
+  - npm config set registry //registry.npmjs.org/:_authToken=${NPM_TOKEN}
   - npm prune
   - git config --global user.email "jonelson+lerna-sr-travis-ci@atlassian.com"
   - git config --global user.name "Joshua Nelson"


### PR DESCRIPTION
Currently when installing locally it fails because of the missing `NPM_TOKEN` environment variable.

Added username and email to the travis build config.
