### PR TITLE
refactor: Removes committing & pushing the changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ lerna-semantic-release pre # Set up the versions, tags and commits
 lerna-semantic-release perform # Publishes to npm
 
 # Post
-lerna-semantic-release post # Generates a changelog in each package
+lerna-semantic-release post # Generates a changelog in each package in a file named CHANGELOG.md - will not commit or push that file any more after version 7.0.5 any more. If you want to do something with it, you will need to do this manually.
 
 This will publish all npm packages, including creating commits and tags for each release, in the format that lerna expects for the `lerna updated` command.

--- a/packages/lerna-semantic-release-post/index.js
+++ b/packages/lerna-semantic-release-post/index.js
@@ -93,15 +93,6 @@ function createChangelog (done) {
   });
 }
 
-function enterPackage (done) {
-  this.io.shell.pushdSync(this.packagePath);
-  done();
-}
-function exitPackage (done) {
-  this.io.shell.popdSync();
-  done();
-}
-
 function isTagRelevant (packageName, tag) {
   var tagParts = tagging.getTagParts(tag);
   return tagParts && tagParts.version && tagParts.name === packageName;
@@ -144,11 +135,7 @@ module.exports = function (config) {
   forEachPackage([
     createSemverTags,
     createChangelog,
-    removeSemverTags,
-    enterPackage,
-    config.io.shell.touch(CHANGELOG_FILE_NAME),
-    config.io.git.add(CHANGELOG_FILE_NAME),
-    exitPackage
+    removeSemverTags
   ], {
     allPackages: config.io.lerna.getAllPackages(),
     extraContext: {
@@ -156,13 +143,8 @@ module.exports = function (config) {
       io: config.io
     }
   }, function done () {
-    async.series([
-      config.io.git.commit('docs(changelog): appending to changelog'),
-      config.io.git.push()
-    ], (err) => {
-      if (typeof config.callback === 'function') {
-        config.callback(err);
-      }
-    });
+    if (typeof config.callback === 'function') {
+      config.callback(err);
+    }
   });
 };

--- a/packages/lerna-semantic-release-post/test/unit.js
+++ b/packages/lerna-semantic-release-post/test/unit.js
@@ -220,19 +220,6 @@ describe('post', function() {
       afterEach(function () {
         io.restore();
       });
-
-      describe('executing', function () {
-        beforeEach(function (done) {
-          post({
-            io: io,
-            callback: done
-          });
-        });
-
-        it('git push is called once', function () {
-          expect(io.git.push.innerTask.callCount).to.equal(1);
-        });
-      });
     });
   });
 


### PR DESCRIPTION
affects: lerna-semantic-release-post

BREAKING CHANGE: does not longer commit & push the CHANGELOG.md file

Related to: https://ecosystem.atlassian.net/browse/AK-153
