### PR TITLE
docs(readme): fix commitizen link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Next, initialize your project to use the cz-lerna-changelog adapter by typing:
 commitizen init cz-lerna-changelog --save-dev --save-exact
 ```
 
-See the [commitzien-cli](https://github.com/commitizen/cz-cli) docs for more details on how to set up commitzen with the correct adapter.
+See the [commitizen-cli](https://github.com/commitizen/cz-cli) docs for more details on how to set up commitzen with the correct adapter.
 
 ### Setting up the build
 


### PR DESCRIPTION
Replace 'commitzien-cli' with 'commitizen-cli'.
