### PR TITLE
Fix multiline affects

### DIFF
--- a/packages/lerna-semantic-release-analyze-commits/index.js
+++ b/packages/lerna-semantic-release-analyze-commits/index.js
@@ -4,10 +4,9 @@ var affectsDelimiter = 'affects:';
 
 function findAffectsLine(commit) {
   var message = (commit && commit.message) ? commit.message : '';
-  var affectsLine = message.split('\n\n').filter(function (line) {
+  var affectsLine = message.split('\n').filter(function (line) {
     return line.indexOf(affectsDelimiter) === 0;
   })[0];
-  console.log(affectsLine);
   return affectsLine;
 }
 

--- a/packages/lerna-semantic-release-analyze-commits/index.js
+++ b/packages/lerna-semantic-release-analyze-commits/index.js
@@ -1,5 +1,15 @@
 var commitAnalyzer = require('@semantic-release/commit-analyzer');
 var log = require('lerna-semantic-release-utils').log;
+var affectsDelimiter = 'affects:';
+
+function findAffectsLine(commit) {
+  var message = (commit && commit.message) ? commit.message : '';
+  var affectsLine = message.split('\n\n').filter(function (line) {
+    return line.indexOf(affectsDelimiter) === 0;
+  })[0];
+  console.log(affectsLine);
+  return affectsLine;
+}
 
 module.exports = {
   analyze: function (_ref, cb) {
@@ -7,8 +17,7 @@ module.exports = {
     var commits = _ref.commits;
 
     var relevantCommits = commits.filter(function (commit) {
-      var affectsLine = (commit && commit.message) ? commit.message.split('\n\n')[1] : '';
-      return module.exports.isRelevant(affectsLine, pkg.name);
+      return module.exports.isRelevant(findAffectsLine(commit), pkg.name);
     });
 
     commitAnalyzer({}, Object.assign(_ref, {commits: relevantCommits}), function (err, type) {
@@ -19,9 +28,7 @@ module.exports = {
       cb(err, type);
     });
   },
-
   isRelevant: function (affectsLine, packageName) {
-    var affectsDelimiter = 'affects:';
     return affectsLine && affectsLine.indexOf(affectsDelimiter) === 0 &&
       affectsLine.split(affectsDelimiter)[1].trim().split(', ').indexOf(packageName) > -1;
   }

--- a/packages/lerna-semantic-release-analyze-commits/package.json
+++ b/packages/lerna-semantic-release-analyze-commits/package.json
@@ -22,7 +22,11 @@
     "branch": "caribou"
   },
   "scripts": {
-    "test": "echo 'no tests'; exit 0"
+    "test": "mocha test/unit.js"
   },
-  "version": "4.0.13"
+  "version": "4.0.13",
+  "devDependencies": {
+    "expect.js": "^0.3.1",
+    "mocha": "^3.0.2"
+  }
 }

--- a/packages/lerna-semantic-release-analyze-commits/test/unit.js
+++ b/packages/lerna-semantic-release-analyze-commits/test/unit.js
@@ -1,0 +1,76 @@
+var expect = require('expect.js');
+var analyzeCommits = require('../index');
+
+describe('analyzing commits', function() {
+  it('detects the correct fix version when the commit has two lines', function (done) {
+    var commit = {"hash":"6fcf2d","message":"fix(package): first line\n\nsecond line.\n\naffects: pkg-a, pkg-b, pkg-c\n"};
+
+    analyzeCommits.analyze({
+      pkg: {name: 'pkg-b'},
+      commits: [commit],
+    }, function(err, type) {
+      expect(err).to.equal(null);
+      expect(type).to.equal('patch');
+      done();
+    });
+  });
+  it('detects the correct fix version when the commit has one line', function (done) {
+    var commit = {"hash":"6fcf2d","message":"fix(package): first line\n\naffects: pkg-a, pkg-b, pkg-c\n"};
+
+    analyzeCommits.analyze({
+      pkg: {name: 'pkg-b'},
+      commits: [commit],
+    }, function(err, type) {
+      expect(err).to.equal(null);
+      expect(type).to.equal('patch');
+      done();
+    });
+  });
+  describe('acts like semantic release', function () {
+    var commits = [
+      {"hash":"abcde4","message":"fix(package): first line\n\naffects: pkg-a\n"},
+      {"hash":"abcde3","message":"feat(package): first line\n\naffects: pkg-a, pkg-b\n"},
+      {"hash":"abcde2","message":"fix(package): first line\n\nBREAKING CHANGE: something\n\naffects: pkg-d\n"},
+      {"hash":"abcde1","message":"chore(package): first line\n\naffects: pkg-a, pkg-b, pkg-c\n"},
+    ];
+    function expectType(packageName, expectedType, cb) {
+      analyzeCommits.analyze({
+        pkg: {name: packageName},
+        commits: commits,
+      }, function(err, type) {
+        expect(err).to.equal(null);
+        expect(type).to.equal(expectedType);
+        cb();
+      });
+    }
+    it('chore + feat = minor', function(done) {
+      expectType('pkg-b', 'minor', done);
+    });
+    it('chore + feat + fix = minor', function(done) {
+      expectType('pkg-a', 'minor', done);
+    });
+    it('chore = null', function(done) {
+      expectType('pkg-b', 'minor', done);
+    });
+    it('break = major', function(done) {
+      expectType('pkg-d', 'major', done);
+    });
+  });
+  //TODO: I think this test *should* pass but it does not.
+  //See https://github.com/atlassian/lerna-semantic-release/issues/33
+  it.skip('still detects changes after revert', function (done) {
+    var commits = [
+      {"hash":"abcdef","message":"Revert \"fix(package): first line\"\n\nThis reverts commit 6fcf2d.\n"},
+      {"hash":"6fcf2d","message":"fix(package): first line\n\naffects: pkg-a, pkg-b, pkg-c\n"},
+    ];
+
+    analyzeCommits.analyze({
+      pkg: {name: 'pkg-b'},
+      commits: commits,
+    }, function(err, type) {
+      expect(err).to.equal(null);
+      expect(type).to.equal('patch');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
There was a problem where commits with multiple lines and then an affects line didn't trigger releases.

I'm quite surprised that this hasn't been picked up already
