### PR TITLE
fix: use main line of semantic-release

### DIFF
--- a/packages/lerna-semantic-release-io/package.json
+++ b/packages/lerna-semantic-release-io/package.json
@@ -9,7 +9,7 @@
     "lerna-semantic-release-utils": "^4.0.0",
     "lerna-semantic-release-analyze-commits": "^4.0.0",
     "lerna-semantic-release-get-last-release": "^5.0.0",
-    "semantic-release": "semantic-release/semantic-release#a5cb9ea7f7a66657f95f0d913126e812adb6d9f8",
+    "semantic-release": "^6.3.1",
     "@semantic-release/last-release-npm": "~1.2.1",
     "shelljs": "~0.7.0",
     "simple-git": "~1.48.0",

--- a/packages/lerna-semantic-release-pre/package.json
+++ b/packages/lerna-semantic-release-pre/package.json
@@ -10,7 +10,7 @@
     "async": "~2.0.1",
     "npmconf": "~2.1.0",
     "rc": "~1.1.0",
-    "semantic-release": "semantic-release/semantic-release#a5cb9ea7f7a66657f95f0d913126e812adb6d9f8"
+    "semantic-release": "^6.3.1"
   },
   "devDependencies": {
     "mocha": "~3.0.2",


### PR DESCRIPTION
PR got merged, we can use the mainline again
