### PR TITLE
Upgrade and migrate to lerna 2.0.0-beta.31

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "lerna": "2.0.0-beta.26",
+  "lerna": "2.0.0-beta.31",
   "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "devDependencies": {
     "lerna-semantic-release": "^8.0.0",
-    "lerna": "2.0.0-beta.26",
+    "lerna": "2.0.0-beta.31",
     "cz-lerna-changelog": "0.2.1"
   },
   "repository": {

--- a/packages/lerna-semantic-release-io/io/lerna.js
+++ b/packages/lerna-semantic-release-io/io/lerna.js
@@ -3,7 +3,7 @@ var PackageUtilities = require('lerna/lib/PackageUtilities');
 
 module.exports = {
   getAllPackages: function () {
-    var packagesLocation = new Repository().packagesLocation;
-    return PackageUtilities.getPackages(packagesLocation);
+    var repository = new Repository();
+    return PackageUtilities.getPackages(repository);
   }
 };


### PR DESCRIPTION
When using the latest lerna version `2.0.0-beta.31`, they changed how to
get the packages list in the `PackageUtilities.js` module.
https://github.com/lerna/lerna/releases
https://github.com/lerna/lerna/pull/365/files#diff-f960c1351bdddb47ae2faca5a42f319bR31