### PR TITLE
fix(tagging): Fix situation when lerna-semantic-release-post overwrites existing entries in CHANGELOG

### DIFF
--- a/packages/lerna-semantic-release-utils/package.json
+++ b/packages/lerna-semantic-release-utils/package.json
@@ -23,7 +23,11 @@
     "branch": "caribou"
   },
   "scripts": {
-    "test": "echo 'no tests'; exit 0"
+    "test": "mocha test/unit.js"
   },
-  "version": "4.0.13"
+  "version": "4.0.13",
+  "devDependencies": {
+    "expect.js": "^0.3.1",
+    "mocha": "^3.2.0"
+  }
 }

--- a/packages/lerna-semantic-release-utils/tagging.js
+++ b/packages/lerna-semantic-release-utils/tagging.js
@@ -10,10 +10,13 @@ module.exports = {
   },
 
   getTagParts: function getTagParts (tag) {
-    if (tag.indexOf('@') > -1) {
+    // we use lastIndex to skip leading "@" for namespaced packages
+    const indexOfNameVersionSeparator = tag.lastIndexOf('@');
+
+    if (indexOfNameVersionSeparator > -1) {
       return {
-        name: tag.split('@')[0],
-        version: tag.split('@')[1]
+        name: tag.substring(0, indexOfNameVersionSeparator),
+        version: tag.substring(indexOfNameVersionSeparator + 1)
       }
     }
 

--- a/packages/lerna-semantic-release-utils/test/unit.js
+++ b/packages/lerna-semantic-release-utils/test/unit.js
@@ -1,0 +1,26 @@
+const expect = require('expect.js');
+const utils = require('../index');
+
+describe('tagging', function() {
+
+  const tagging = utils.tagging;
+
+  describe('getTagParts', function() {
+
+    it('should work with regular package names', function () {
+      expect(tagging.getTagParts('my-regular-package@1.0.0')).to.eql({
+        name: 'my-regular-package',
+        version: '1.0.0'
+      });
+    });
+
+    it('should work with namespaced package names', function () {
+      expect(tagging.getTagParts('@my-org/my-namespaced-package@9.9.9')).to.eql({
+        name: '@my-org/my-namespaced-package',
+        version: '9.9.9'
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
affects: lerna-semantic-release, lerna-semantic-release-utils

It happens because our tagging implementation fails to split name and version of a namespaced
package in tag

closes #44 