### PR TITLE
fix(namespaced packages): fix the tagging of the namespaced packages

### DIFF
--- a/packages/lerna-semantic-release-utils/tagging.js
+++ b/packages/lerna-semantic-release-utils/tagging.js
@@ -1,4 +1,6 @@
 var semverSeparator = '-semver-tag-for-';
+var packageNamespacePrefix = '--namespace-prefix--';
+var packageNamespaceSeparator = '--namespace-separator--';
 
 module.exports = {
   lerna: function lerna (name, version) {
@@ -6,10 +8,38 @@ module.exports = {
   },
 
   semver: function semver (name, version) {
-    return [version, semverSeparator, name].join('');
+    // make sure the special chars are escaped
+    // in case a package name contains namespace
+    // because otherwise the generated tag won't pass
+    // validation for being a valid semver tag
+    var nameWithNamespaceEscaped = name
+      .replace('@', packageNamespacePrefix)
+      .replace('/', packageNamespaceSeparator);
+
+    return [version, semverSeparator, nameWithNamespaceEscaped].join('');
   },
 
   getTagParts: function getTagParts (tag) {
+    if (!tag) {
+      return null;
+    }
+
+    // handle semver tags
+    if (tag.indexOf(semverSeparator) > -1) {
+      var version = tag.split(semverSeparator)[0];
+      var name = tag.split(semverSeparator)[1];
+      name = name
+        .replace(packageNamespacePrefix, '@')
+        .replace(packageNamespaceSeparator, '/');
+
+      return {
+        name: name,
+        version: version
+      }
+    }
+
+    // handle lerna tags
+
     // we use lastIndex to skip leading "@" for namespaced packages
     const indexOfNameVersionSeparator = tag.lastIndexOf('@');
 
@@ -17,13 +47,6 @@ module.exports = {
       return {
         name: tag.substring(0, indexOfNameVersionSeparator),
         version: tag.substring(indexOfNameVersionSeparator + 1)
-      }
-    }
-
-    if (tag.indexOf(semverSeparator) > -1) {
-      return {
-        name: tag.split(semverSeparator)[1],
-        version: tag.split(semverSeparator)[0]
       }
     }
   }

--- a/packages/lerna-semantic-release-utils/test/unit.js
+++ b/packages/lerna-semantic-release-utils/test/unit.js
@@ -5,21 +5,63 @@ describe('tagging', function() {
 
   const tagging = utils.tagging;
 
+  describe('lerna', function() {
+    it('should generate correct lerna tag for regular packages', function() {
+      expect(tagging.lerna('my-regular-package', '3.3.3')).to.be('my-regular-package@3.3.3');
+    });
+
+    it('should generate correct lerna tag for namespaced packages', function() {
+      expect(tagging.lerna('@my-org/my-namespaced-package', '1.0.0')).to.be('@my-org/my-namespaced-package@1.0.0');
+    });
+  });
+
+  describe('semver', function() {
+    it('should generate correct temporary semver tag for regular packages', function() {
+      expect(tagging.semver('my-regular-package', '3.3.3')).to.be('3.3.3-semver-tag-for-my-regular-package');
+    });
+
+    it('should generate correct temporary semver tag for namespaced packages', function() {
+      expect(tagging.semver('@my-org/my-namespaced-package', '1.0.0')).to.be(
+        '1.0.0-semver-tag-for---namespace-prefix--my-org--namespace-separator--my-namespaced-package'
+      );
+    });
+  });
+
   describe('getTagParts', function() {
 
-    it('should work with regular package names', function () {
-      expect(tagging.getTagParts('my-regular-package@1.0.0')).to.eql({
-        name: 'my-regular-package',
-        version: '1.0.0'
+    describe('when lerna tag is passed', function() {
+      it('should work with regular package names', function () {
+        expect(tagging.getTagParts('my-regular-package@1.0.0')).to.eql({
+          name: 'my-regular-package',
+          version: '1.0.0'
+        });
+      });
+
+      it('should work with namespaced package names', function () {
+        expect(tagging.getTagParts('@my-org/my-namespaced-package@9.9.9')).to.eql({
+          name: '@my-org/my-namespaced-package',
+          version: '9.9.9'
+        });
       });
     });
 
-    it('should work with namespaced package names', function () {
-      expect(tagging.getTagParts('@my-org/my-namespaced-package@9.9.9')).to.eql({
-        name: '@my-org/my-namespaced-package',
-        version: '9.9.9'
+    describe('when temporary semver tag is passed', function() {
+      it('should work with regular package names', function () {
+        expect(tagging.getTagParts('1.0.0-semver-tag-for-my-regular-package')).to.eql({
+          name: 'my-regular-package',
+          version: '1.0.0'
+        });
       });
-    });
+
+      it('should work with namespaced package names', function () {
+        expect(tagging.getTagParts(
+          '9.9.9-semver-tag-for---namespace-prefix--my-org--namespace-separator--my-namespaced-package'
+        )).to.eql({
+          name: '@my-org/my-namespaced-package',
+          version: '9.9.9'
+        });
+      });
+    })
 
   });
 


### PR DESCRIPTION
affects: lerna-semantic-release, lerna-semantic-release-utils

Tagging functionality didn't work correctly for the namespaced packages e.g. `@my-org/my-package`. The temporary semver tag generated for such packages contained the special chars (`@`, `/`) which did not pass the semver validation, thus being ignored by the changelog generation scripts of `lerna-semantic-release-post`

This commit fixes that