### PR TITLE
fix(perform): Adds process.exit(1) to perform step when error occurs

### DIFF
--- a/packages/lerna-semantic-release-perform/index.js
+++ b/packages/lerna-semantic-release-perform/index.js
@@ -145,6 +145,7 @@ module.exports = function perform (config) {
   function (err) {
     if (err) {
       log.error(err.message);
+      process.exit(1);
     }
     if (typeof config.callback === 'function') {
       config.callback(err);


### PR DESCRIPTION
We **think** this is what is masking an error in our build.

In any case it should be a risk free addition.