### PR TITLE
feat(lerna-semantic-release-perform): add a cli flag to perform (--dont-pull)

### DIFF
--- a/packages/lerna-semantic-release-perform/index.js
+++ b/packages/lerna-semantic-release-perform/index.js
@@ -18,7 +18,11 @@ function pullTags (done) {
 }
 
 function pullCommits (done) {
-  this.io.git.pull()(function(err) {
+  if (this.flags.dontPull) {
+    return done();
+  }
+
+  return this.io.git.pull()(function(err) {
     done(err);
   });
 }
@@ -140,7 +144,8 @@ module.exports = function perform (config) {
     publishUpdatedPackages,
     writeReleasedPackagesFile
   ], {
-    io: config.io
+    io: config.io,
+    flags: config.flags || {},
   }),
   function (err) {
     if (err) {


### PR DESCRIPTION
feat(lerna-semantic-release-perform): add a cli flag to perform (--dont-pull) to control 
whether to pull commit from origin during perform

affects: lerna-semantic-release-perform

if perform is running and changes have been merged upstread they will be used inside perform.
this will lead to packages being released that have not passed CI