### PR TITLE
feat: add env var override for get-last-release use local strategy

### DIFF
--- a/packages/lerna-semantic-release-get-last-release/index.js
+++ b/packages/lerna-semantic-release-get-last-release/index.js
@@ -8,7 +8,7 @@ module.exports = function (pluginConfig, _ref, cb) {
   const revParse = pluginConfig.revParse;
   const tagList = pluginConfig.tagList;
 
-  if (pkg.private) {
+  if (pkg.private || process.env.GET_LAST_RELEASE_FROM_TAGS) {
     log.info('Package', pkg.name, 'is marked as private, doing last version calculation locally');
     const version = pkg.version;
     const versionTag = tagging.lerna(pkg.name, version);


### PR DESCRIPTION
The underlying semantic-release get-last-release plugin has all sorts of problems in their issues tracker about working with private npm registries (and seems slow and non-responsive in merging PRs).

Thankfully, the strategy in lerna-semantic-release-get-last-release of looking at git tags works great! The problem is, with a private npm registry, the package.json doesn't have `private: true`, so this package fails to detect it, and falls back to the default (non-working) strategy.

This PR lets you force the local git tag-based get-last-release strategy by setting an env var `GET_LAST_RELEASE_FROM_TAGS`.

I didn't see any other convention already established in this project for setting config (or overriding plugins, which would let me make this change in my setup without needing to push it upstream into lerna-semantic-release), so I went with an env var as an easy default - but I'm more than willing to discuss an alternate implementation. What I'm trying to achieve is a way to force lerna-semantic-release to always use the local get-last-version strategy.

Thanks!