### PR TITLE
Remove duplicate headers from changelog

### DIFF
--- a/packages/lerna-semantic-release-analyze-commits/index.js
+++ b/packages/lerna-semantic-release-analyze-commits/index.js
@@ -25,7 +25,7 @@ module.exports = {
       if (thisPackage.indexOf('@') === -1 || thisPackage.lastIndexOf('@') === 0) {
         return thisPackage === packageName;
       }
-      return thisPackage.substring(0, thisPackage.lastIndexOf('@')) === packageName;
+      return false;
     }));
   },
   getAffectedPackages: function (affectsLine) {


### PR DESCRIPTION
Exclude chore (release) commits from changelog setting them as not relevant.
Fix #77 